### PR TITLE
fix step order for js translations

### DIFF
--- a/uberspace/deploy.yml
+++ b/uberspace/deploy.yml
@@ -122,14 +122,14 @@
     - name: django collectstatic
       shell: source ~/ephios.env && python3.8 -m ephios collectstatic --no-input
 
-    - name: django compile i18n javascript
-      shell: source ~/ephios.env && python3.8 -m ephios compilejsi18n
-
     - name: django compilemessages
       shell: source ~/ephios.env && python3.8 -m ephios compilemessages
       notify:
       - restart uwsgi
 
+    - name: django compile i18n javascript
+      shell: source ~/ephios.env && python3.8 -m ephios compilejsi18n
+      
 
     - name: copy ephios uwsgi config
       template:


### PR DESCRIPTION
django-statici18n takes the compiled django messages and creates a JS translation catalog from them, so it must run after the compilemessages step.